### PR TITLE
Removed reference to non-existing file (addresses #60)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,9 +214,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>2.4.1</version>
-				<configuration>
+				<!-- configuration>
 					<descriptor>src/main/assembly/bin.xml</descriptor>
-				</configuration>
+				</configuration -->
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
I guess the file actually makes a few uncommon things and is important, but just want to let you know that with this patch at least Maven completes. Ignore this patch at wish.