### PR TITLE
Implement DOI resolver recommendation

### DIFF
--- a/src/main/resources/org/xmlcml/norma/pubstyle/nlm/toHtml.xsl
+++ b/src/main/resources/org/xmlcml/norma/pubstyle/nlm/toHtml.xsl
@@ -9,7 +9,7 @@
 	<xsl:variable name="publisher">Generic NLM</xsl:variable>
 	<xsl:variable name="prefix">10.0000</xsl:variable>
     
-    <xsl:variable name="doiroot">https://dx.doi.org/</xsl:variable>
+    <xsl:variable name="doiroot">https://doi.org/</xsl:variable>
     <xsl:variable name="nlmroot">http://www.ncbi.nlm.nih.gov/pubmed/</xsl:variable>    
 	<xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'" />
 	<xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />


### PR DESCRIPTION
See https://www.doi.org/doi_handbook/3_Resolution.html#3.8

I have a script that could switch [all these old DOI URLs](https://github.com/search?q=org%3AContentMine+%22dx.doi%22&type=Code), but I'm guessing that is only useful for some filetypes or uses.

If I'm guessing correctly and you are interested in more such PRs, please let me know where the updates are most useful.